### PR TITLE
Backward compatibility with version 1.0

### DIFF
--- a/consistent_hash/consistent_hash.py
+++ b/consistent_hash/consistent_hash.py
@@ -12,9 +12,6 @@ import bisect
 import re
 import sys
 
-if sys.version_info[0] == 3:
-    xrange = range
-
 
 class ConsistentHash(object):
 
@@ -123,9 +120,9 @@ class ConsistentHash(object):
 
         factor = self.interleave_count * weight
 
-        for j in xrange(0, int(factor)):
+        for j in range(int(factor)):
             b_key = self._hash_digest('%s-%s' % (node, j))
-            for i in xrange(4):
+            for i in range(3):
                 yield self._hash_val(b_key, lambda x: x + i * 4)
 
     def get_node(self, string_key):

--- a/consistent_hash/consistent_hash.py
+++ b/consistent_hash/consistent_hash.py
@@ -12,6 +12,9 @@ import bisect
 import re
 import sys
 
+if sys.version_info[0] == 3:
+    xrange = range
+
 
 class ConsistentHash(object):
 
@@ -120,9 +123,9 @@ class ConsistentHash(object):
 
         factor = self.interleave_count * weight
 
-        for j in range(int(factor)):
+        for j in xrange(0, int(factor)):
             b_key = self._hash_digest('%s-%s' % (node, j))
-            for i in range(3):
+            for i in xrange(3):
                 yield self._hash_val(b_key, lambda x: x + i * 4)
 
     def get_node(self, string_key):

--- a/tests/consistent_hash_tests.py
+++ b/tests/consistent_hash_tests.py
@@ -164,3 +164,40 @@ class TestConsistentHash:
         for i in range(num):
             objs.append(''.join([random.choice(chars) for i in range(len)]))
         return objs
+
+    def test_sample_hash_output(self):
+        ConsistentHash.interleave_count = 40
+        # Test backward compatibility with version 1.0
+        samples = {
+            '35132097': 'B',
+            '25291004': 'D',
+            '48182416': 'F',
+            '45818378': 'H',
+            '52733021': 'A',
+            '94027025': 'I',
+            '18116713': 'F',
+            '75531098': 'J',
+            '99011825': 'F',
+            '99371754': 'A',
+            '19630740': 'D',
+            '87823770': 'G',
+            '32160063': 'A',
+            '28054420': 'E',
+            '75904283': 'H',
+            '08458048': 'E',
+            '51583844': 'I',
+            '16226754': 'B',
+            '95450503': 'E',
+            '47557476': 'C',
+            '38808589': 'A',
+        }
+
+        hash_ring = ConsistentHash(objects=['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'])
+        for input, output in samples.items():
+            result = hash_ring.get_node(input)
+            if result != output:
+                raise Exception('Expected node does not match actual node. Expected: {}. Got: {}'.format(
+                        output,
+                        result,
+                    )
+                )


### PR DESCRIPTION
Range was changed from 3 to 4 in 7c2963f. This leads to inconsistent returned values from version 1.0.

Moving back to 3 to make it backward compatible and adding tests to make sure is not broken again.
